### PR TITLE
Config in parent package should take preference to child packages

### DIFF
--- a/npm-load.js
+++ b/npm-load.js
@@ -125,8 +125,8 @@ var translateConfig = function(loader, packages, options){
 		loader.npmParentMap = options.npmParentMap || {};
 	}
 	var rootPkg = loader.npmPaths.__default = packages[0];
-	var steal = rootPkg.steal || rootPkg.system;
-	var lib = steal && steal.directories && steal.directories.lib;
+	var rootConfig = rootPkg.steal || rootPkg.system;
+	var lib = rootConfig && rootConfig.directories && rootConfig.directories.lib;
 
 	var setGlobalBrowser = function(globals, pkg){
 		for(var name in globals) {
@@ -162,7 +162,9 @@ var translateConfig = function(loader, packages, options){
 			});
 		}
 	};
+
 	var ignoredConfig = ["bundle", "configDependencies", "transpiler"];
+	packages.reverse();
 	forEach(packages, function(pkg){
 		var steal = pkg.steal || pkg.system;
 		if(steal) {
@@ -184,7 +186,7 @@ var translateConfig = function(loader, packages, options){
 		}
 		if(pkg.globalBrowser) {
 			var doNotApplyGlobalBrowser = pkg.name === "steal" &&
-				loader.builtins === false;
+				rootConfig.builtins === false;
 			if(!doNotApplyGlobalBrowser) {
 				setGlobalBrowser(pkg.globalBrowser, pkg);
 			}

--- a/test/contextual_map/my-moment.js
+++ b/test/contextual_map/my-moment.js
@@ -1,5 +1,5 @@
 var dep = require("dep");
-var moment = require("moment_lib");
+var moment = require("./moment_lib");
 
 module.exports = {
 	name: "my-moment",

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -220,7 +220,6 @@ QUnit.test("Previous packages are included in the package.json!npm source",
 
 	helpers.init(loader)
 	.then(function(){
-		console.log("here");
 		var load = loader.getModuleLoad("package.json!npm");
 		var hasPkg = load.source.indexOf("some-pkg") !== -1;
 		assert.ok(hasPkg, "the previous packages were applied to the source");
@@ -271,7 +270,6 @@ QUnit.test("Configuration can be put on the 'system' object in package.json",
 	})
 	.then(done, helpers.fail(assert, done));
 });
-
 
 QUnit.module("Importing npm modules with tilde operator");
 

--- a/test/map_same/package.json
+++ b/test/map_same/package.json
@@ -7,7 +7,7 @@
 	},
 	"system": {
 		"map": {
-			"can": "./can"
+			"can": "mod#can"
 		}
 	}
 }

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -444,6 +444,48 @@ QUnit.test("normalizes in production when there is a dep in a parent node_module
 
 });
 
+QUnit.test("Child config doesn't override root config", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			steal: {
+				ext: {
+					foo: "bar"
+				}
+			},
+			dependencies: {
+				child: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "child",
+				version: "1.0.0",
+				main: "main.js",
+				steal: {
+					ext: {
+						foo: "qux"
+					}
+				}
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		return loader.normalize("./mod.foo", "app@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "app@1.0.0#mod.foo!bar", "uses the ext config from the root package");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
+
 QUnit.module("normalizing with main config");
 
 var mainVariations = {

--- a/test/test.js
+++ b/test/test.js
@@ -55,7 +55,7 @@ asyncTest("Loads globals", function(){
 
 
 asyncTest("meta", function(){
-	GlobalSystem["import"]("test/meta").then(function(meta){
+	GlobalSystem["import"]("~/test/meta").then(function(meta){
 		equal(meta,"123", "got 123");
 	}).then(start);
 });
@@ -81,14 +81,14 @@ asyncTest("jquery-ui", function(){
 
 asyncTest("import self", function(){
 	GlobalSystem.globalBrowser = {
-		"system-npm": "system-npm"
+		"steal-npm": "steal-npm"
 	};
 	Promise.all([
-		GlobalSystem["import"]("system-npm"),
-		GlobalSystem["import"]("system-npm/test/meta")
+		GlobalSystem["import"]("steal-npm"),
+		GlobalSystem["import"]("steal-npm/test/meta")
 	]).then(function(mods){
 		equal(mods[0], "example-main", "example-main");
-		equal(mods[1], "123", "system-npm/test/meta");
+		equal(mods[1], "123", "steal-npm/test/meta");
 	}).then(start);
 });
 


### PR DESCRIPTION
This fixes #185

Changes the way package config is applied, now in reverse order, so that
the root package's config is applied last, making it so that it
overrides any child config.

This doesn't fix the issue of progressively loaded configuration, that
problem is probably unfixable as long as we allow child packages to
override global configuration.

Closes #185