### PR TITLE
Set load.metadata.address in the case of a retry

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -391,7 +391,7 @@ exports.addExtension = function(System){
 				return loader.fetch(local);
 			})
 			.then(function(source){
-				load.address = local.address;
+				load.metadata.address = local.address;
 				loader.npmParentMap[load.name] = local.name;
 				var npmLoad = loader.npmContext &&
 					loader.npmContext.npmLoad;

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -549,8 +549,11 @@ QUnit.test("Retries /package convention as well", function(assert){
 		.loader;
 
 	loader["import"]("./package", { name : "app@1.0.0#main" })
-	.then(function(mod){
+	.then(function(mod) {
+		var pkgAddress = loader.getModuleLoad("app@1.0.0#package").metadata.address;
+
 		assert.equal(mod, "works", "loaded the package.json");
+		assert.ok(/\.json/.test(pkgAddress), "load.medatada.address has json");
 	})
 	.then(done, helpers.fail(assert, done));
 });


### PR DESCRIPTION
This will enable other extensions to use this information. `load.address` itself cannot be mutated.