### PR TITLE
When building, save previous resolutions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
 script: npm test
 sudo: false
 addons:
-  firefox: "43.0"
+  firefox: "50.0"

--- a/npm-load.js
+++ b/npm-load.js
@@ -220,6 +220,12 @@ exports.addExistingPackages = function(context, existingPackages){
 			if(!packages[nameAndVersion]) {
 				packages.push(pkg);
 				packages[nameAndVersion] = true;
+			} else {
+				var curPkg = utils.filter(packages, function(p){
+					return p.name === pkg.name && p.version === pkg.version;
+				})[0];
+				if(!curPkg) return;
+				utils.extend(curPkg.resolutions || {}, pkg.resolutions || {});
 			}
 		});
 	}

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -207,6 +207,47 @@ QUnit.test("`transpiler` config in child pkg is ignored", function(assert){
 	.then(done, helpers.fail(assert, done));
 });
 
+QUnit.test("'resolutions' config is preserved", function(assert){
+	var done = assert.async();
+
+	var appModule = "module.exports = 'worked';";
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				"dep": "1.0.0"
+			}
+		})
+		.withPackages([{
+			name: "dep",
+			main: "main.js",
+			version: "1.0.0"
+		}])
+		.loader;
+
+	loader.npmContext = {
+		pkgInfo: [
+			{name:"dep",main:"main.js",version:"1.0.0", resolutions: {
+				other: "1.0.0"
+			}}
+		]
+	};
+	loader.npmContext.pkgInfo["dep@1.0.0"] = true;
+
+	helpers.init(loader)
+	.then(function(){
+		let pkg = utils.filter(loader.npmContext.pkgInfo, function(pkg){
+			return pkg.name === "dep" && pkg.version === "1.0.0";
+		})[0];
+		assert.equal(pkg.resolutions.other, "1.0.0");
+	})
+	.then(done, helpers.fail(assert, done));
+	
+});
+
 QUnit.module("Importing npm modules using 'browser' config");
 
 QUnit.test("Array property value", function(assert){


### PR DESCRIPTION
A *resolution* is a mapping of dependencies to the version numbers that
are used for a package. During the build we need to remember previous
resolutions in a bundle scenario, because the package.json config is
continuously rewritten. Fixes #195