### PR TITLE
Copy over progressively loaded pkgs to localLoader

### DIFF
--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -70,9 +70,14 @@ var crawl = {
 
 			// Save this pkgInfo into the context
 			var localPkg = convert.toPackage(context, childPkg);
-
 			convert.forPackage(context, childPkg);
-			
+
+			// If this is a build we need to copy over the configuration
+			// from the plugin loader to the localLoader.
+			if(context.loader.localLoader) {
+				var localContext = context.loader.localLoader.npmContext;
+				convert.toPackage(localContext, childPkg);
+			}
 
 			// Save package.json!npm load
 			npmModuleLoad.saveLoadIfNeeded(context);

--- a/npm-load.js
+++ b/npm-load.js
@@ -20,9 +20,13 @@ exports.saveLoad = function(context){
 
 exports.saveLoadIfNeeded = function(context){
 	// Only do the actual saving in the build
-	var loader = context.loader;
 	if(context.resavePackageInfo) {
 		exports.saveLoad(context);
+
+		var localLoader = context.loader.localLoader;
+		if(localLoader) {
+			exports.saveLoad(localLoader.npmContext);
+		}
 	}
 };
 


### PR DESCRIPTION
During the build there are 2 loaders. Configuration that only exists
within the pluginLoader needs to be copied over to the localLoader,
	   because that's the loader who's package.json!npm source is used
	   in production.

When progressive loading, we need to ensure that this configuration is
applied to both loaders.

Closes #200