### PR TITLE
Wait to apply configuration for unnormalized packages

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -366,6 +366,17 @@ exports.addExtension = function(System){
 	var oldConfig = System.config;
 	System.config = function(cfg){
 		var loader = this;
+
+		// Use npm-convert if it is available as it is better
+		// and has the ability to push mappings into a waiting queue.
+		if(loader.npmContext) {
+			var context = loader.npmContext;
+			var pkg = context.versions.__default;
+			context.convert.steal(context, pkg, cfg, true);
+			oldConfig.apply(loader, arguments);
+			return;
+		}
+
 		for(var name in cfg) {
 			if(configSpecial[name]) {
 				cfg[name] = configSpecial[name].call(loader, cfg[name]);

--- a/npm.js
+++ b/npm.js
@@ -38,6 +38,7 @@ exports.translate = function(load){
 		deferredConversions: {},
 		npmLoad: npmLoad,
 		crawl: crawl,
+		convert: convert,
 		resavePackageInfo: resavePackageInfo,
 		forwardSlashMap: {},
 		// default file structure for npm 3 and higher
@@ -47,7 +48,7 @@ exports.translate = function(load){
 	var pkg = {origFileUrl: load.address, fileUrl: utils.relativeURI(loader.baseURL, load.address)};
 	crawl.processPkgSource(context, pkg, load.source);
 	var pkgVersion = context.versions[pkg.name] = {};
-	pkgVersion[pkg.version] = pkg;
+	pkgVersion[pkg.version] = context.versions.__default = pkg;
 
 	// backwards compatible for < npm 3
 	var steal = utils.pkg.config(pkg);

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -638,6 +638,44 @@ QUnit.test("Browser", function(assert){
 	.then(done, helpers.fail(assert, done));
 });
 
+QUnit.test("Config applied before normalization will be reapplied after", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				dep: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "dep",
+				main: "main.js",
+				version: "1.0.0"
+			}
+		])
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		// The build applies config after configMain loads
+		loader.config({
+			map: {
+				dep: "dep/build"
+			}
+		});
+
+		return loader.normalize("dep", "app@1.0.0#main");
+	})
+	.then(function(name){
+		assert.equal(name, "dep@1.0.0#build");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 
 QUnit.module("normalizing with main config");
 


### PR DESCRIPTION
Since we now progressively load *all* package.jsons, we need to wait for
config. We already do this for config that is part of a package.json,
	but we also want to do it for any config that comes from
	`steal.config()`.  One example of this is config applied during the
	build.

Closes #203