### PR TITLE
Don't override package.json config

### DIFF
--- a/npm-convert.js
+++ b/npm-convert.js
@@ -34,7 +34,7 @@ exports.forPackage = convertForPackage;
 
 // Translate helpers ===============
 // Given all the package.json data, these helpers help convert it to a source.
-function convertSteal(context, pkg, steal, root, ignoreWaiting) {
+function convertSteal(context, pkg, steal, root, ignoreWaiting, resavePackageInfo) {
 	if(!steal) {
 		return steal;
 	}
@@ -67,7 +67,7 @@ function convertSteal(context, pkg, steal, root, ignoreWaiting) {
 
 			// If we are building we need to resave the package's system
 			// configuration so that it will be written out into the build.
-			if(context.resavePackageInfo) {
+			if(context.resavePackageInfo && resavePackageInfo !== false) {
 				var info = utils.pkg.findPackageInfo(context, pkg);
 				info.steal = info.system = config;
 			}

--- a/npm-extension.js
+++ b/npm-extension.js
@@ -372,7 +372,7 @@ exports.addExtension = function(System){
 		if(loader.npmContext) {
 			var context = loader.npmContext;
 			var pkg = context.versions.__default;
-			context.convert.steal(context, pkg, cfg, true);
+			context.convert.steal(context, pkg, cfg, true, false, false);
 			oldConfig.apply(loader, arguments);
 			return;
 		}

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -662,6 +662,7 @@ QUnit.test("Config applied before normalization will be reapplied after", functi
 	helpers.init(loader)
 	.then(function(){
 		// The build applies config after configMain loads
+		loader.npmContext.resavePackageInfo = true;
 		loader.config({
 			map: {
 				dep: "dep/build"
@@ -672,6 +673,9 @@ QUnit.test("Config applied before normalization will be reapplied after", functi
 	})
 	.then(function(name){
 		assert.equal(name, "dep@1.0.0#build");
+
+		var pkg = loader.npmContext.pkgInfo[0];
+		assert.ok(!pkg.steal.map, "The map shoulded be applied to what saved into the build artifact");
 	})
 	.then(done, helpers.fail(assert, done));
 });


### PR DESCRIPTION
Now so that we can support progressive loading of config that is applied
via loader.config() before the module has been normalized we are placing
that config in a waiting queue. We don't want that config to apply the
root package.json config, because the package.json config is what should
be written out into the main bundle.