### PR TITLE
Progressively loaded plugins are never from the root

### DIFF
--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -93,7 +93,7 @@ var crawl = {
 				}
 			}
 
-			return crawl.loadPlugins(context, childPkg, isRoot, null,
+			return crawl.loadPlugins(context, childPkg, false, null,
 									skipSettingConfig).then(function(){
 				return localPkg;
 			});

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "lodash": "~2.4.1",
     "qunit": "~0.7.5",
     "qunitjs": "^1.22.0",
-    "steal": "^1.0.0-pre.0",
+    "steal": "^1.0.0",
     "steal-conditional": "^0.1.2",
-    "steal-qunit": "^0.1.1",
+    "steal-qunit": "^1.0.0",
     "testee": "^0.2.2"
   },
   "system": {

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -951,6 +951,15 @@ QUnit.test("Works from a dependent package that is progressively loaded", functi
 		])
 		.loader;
 
+	var fetch = loader.fetch;
+	loader.fetch = function(){
+		return Promise.resolve(fetch.apply(this, arguments))
+			.then(null, function(err){
+				assert.ok(false, err.message);
+				return Promise.reject(err);
+			});
+	};
+
 	helpers.init(loader)
 	.then(function(){
 		return loader.normalize("dep/foo.txt", "app@1.0.0#main");


### PR DESCRIPTION
When progressively loading plugin configuration, never do so on behalf
of the root package. The root package's plugins configuration will be
loaded when the package.json is first parsed.

Fixes this prevents us from starting from a too-deep folder (in
		npm 3).

This is for https://github.com/stealjs/steal/issues/957