### PR TITLE
Handle applying configuration on recursive objects

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -11,10 +11,36 @@ var slice = Array.prototype.slice;
 var npmModuleRegEx = /.+@.+\..+\..+#.+/;
 var conditionalModuleRegEx = /#\{[^\}]+\}|#\?.+$/;
 var gitUrlEx = /(git|http(s?)):\/\//;
+var supportsSet = typeof Set === "function";
 
 var utils = {
-	extend: function(d, s, deep){
+	extend: function(d, s, deep, set){
 		var val;
+
+		if(deep) {
+			if(!set) {
+				if(supportsSet) {
+					set = new Set();
+				} else {
+					set = [];
+				}
+			}
+
+			if(supportsSet) {
+				if(set.has(s)) {
+					return s;
+				} else {
+					set.add(s);
+				}
+			} else {
+				if(set.indexOf(s) !== -1) {
+					return s;
+				} else {
+					set.push(s);
+				}
+			}
+		}
+
 		for(var prop in s) {
 			val = s[prop];
 
@@ -22,7 +48,7 @@ var utils = {
 				if(utils.isArray(val)) {
 					d[prop] = slice.call(val);
 				} else if(utils.isObject(val)) {
-					d[prop] = utils.extend({}, val, deep);
+					d[prop] = utils.extend({}, val, deep, set);
 				} else {
 					d[prop] = s[prop];
 				}

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -701,6 +701,7 @@ QUnit.test("Configuration with circular references works", function(assert){
 				something: someObject
 			}
 		});
+		assert.ok(true, "no infinite recursion");
 	})
 	.then(done, helpers.fail(assert, done));
 });

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -680,6 +680,30 @@ QUnit.test("Config applied before normalization will be reapplied after", functi
 	.then(done, helpers.fail(assert, done));
 });
 
+QUnit.test("Configuration with circular references works", function(assert){
+	var done = assert.async();
+
+	var someObject = {};
+	someObject.foo = someObject;
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0"
+		})
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		loader.config({
+			instantiated: {
+				something: someObject
+			}
+		});
+	})
+	.then(done, helpers.fail(assert, done));
+});
 
 QUnit.module("normalizing with main config");
 


### PR DESCRIPTION
When we set up configuration for Steal objects, usually those objects
are static, but in the case of the `instantiated` config, it can contain
any sorts of objects, like Elements which have recursive reflection.

This makes our `extend` function handle recursion properly. Closes #211