### PR TITLE
Save 'resolutions' config when progressively fetching package.jsons

### DIFF
--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -58,7 +58,7 @@ var crawl = {
 		});
 	},
 
-	dep: function(context, pkg, childPkg, isRoot, skipSettingConfig) {
+	dep: function(context, pkg, refPkg, childPkg, isRoot, skipSettingConfig) {
 		var versionAndRange = childPkg.name + "@" + childPkg.version;
 		if(context.fetchCache[versionAndRange]) {
 			return context.fetchCache[versionAndRange];
@@ -98,6 +98,13 @@ var crawl = {
 				});
 			}).then(function(localPkg){
 				if(!skipSettingConfig) {
+					// When progressively fetching package.jsons, we need to save
+					// the 'resolutions' so in production we get the *correct*
+					// version of a dependency.
+					if(refPkg) {
+						utils.pkg.saveResolution(context, refPkg, localPkg);
+					}
+
 					// Save package.json!npm load
 					npmModuleLoad.saveLoadIfNeeded(context);
 
@@ -166,7 +173,7 @@ var crawl = {
 		}, truthy);
 
 		return Promise.all(utils.map(needFetching, function(pluginPkg){
-			return crawl.dep(context, pkg, pluginPkg, isRoot, skipSettingConfig);
+			return crawl.dep(context, pkg, false, pluginPkg, isRoot, skipSettingConfig);
 		}));
 	},
 	/**

--- a/npm-extension.js
+++ b/npm-extension.js
@@ -198,7 +198,7 @@ exports.addExtension = function(System){
 				return oldNormalize.call(this, name, parentName, parentAddress,
 										 pluginNormalize);
 			}
-			return crawl.dep(this.npmContext, parentPkg, depPkg, isRoot)
+			return crawl.dep(this.npmContext, parentPkg, refPkg, depPkg, isRoot)
 				.then(createModuleNameAndNormalize);
 		} else {
 			return createModuleNameAndNormalize(depPkg);

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -505,7 +505,53 @@ QUnit.test("'resolutions' config is preserved", function(assert){
 		assert.equal(pkg.resolutions.other, "1.0.0");
 	})
 	.then(done, helpers.fail(assert, done));
-	
+});
+
+QUnit.test("'resolutions' config is saved during the build for progressively loaded package.jsons", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "one",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				two: "1.0.0"
+			}
+		})
+		.withPackages([
+			{
+				name: "two",
+				main: "main.js",
+				version: "1.0.0",
+				dependencies: {
+					three: "1.0.0"
+				}
+			},
+			{
+				name: "three",
+				version: "1.0.0",
+				main: "main.js"
+			}
+		])
+		.withModule("one@1.0.0#main", "require('two');")
+		.withModule("two@1.0.0#main", "require('three');")
+		.withModule("three@1.0.0#main", "module.exports = 'it worked'")
+		.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		loader.npmContext.resavePackageInfo = true;
+		return loader["import"](loader.main);
+	})
+	.then(function(){
+		var load = loader.getModuleLoad("package.json!npm");
+		var source = load.source;
+
+		assert.ok(/"three": "1.0.0"/.test(source), "it worked");
+	})
+	.then(done, helpers.fail(assert, done));
+
 });
 
 QUnit.module("Importing npm modules using 'browser' config");


### PR DESCRIPTION
This change makes it so that we save the 'resolutions' configuration
when progressively loading package.jsons.