### PR TITLE
Retain steal configuration from previous bundles

### DIFF
--- a/npm-load.js
+++ b/npm-load.js
@@ -235,8 +235,28 @@ exports.addExistingPackages = function(context, existingPackages){
 					return p.name === pkg.name && p.version === pkg.version;
 				})[0];
 				if(!curPkg) return;
-				utils.extend(curPkg.resolutions || {}, pkg.resolutions || {});
+				deeplyExtendPkg(curPkg, pkg);
 			}
 		});
 	}
 };
+
+// Deeply extend the configuration that needs to be kept from
+// a previous bundle that runs through the build process.
+// This makes sure that if we load different configuration for different
+// bundles, all of it is retained for use in production.
+function deeplyExtendPkg(a, b) {
+	if(!a.resolutions) {
+		a.resolutions = {};
+	}
+	utils.extend(a.resolutions, b.resolutions || {});
+
+	if(!a.steal) {
+		a.steal = {};
+	}
+	if(!b.steal) {
+		b.steal = {};
+	}
+
+	utils.extend(a.steal, b.steal, true);
+}

--- a/test/import_test.js
+++ b/test/import_test.js
@@ -551,8 +551,52 @@ QUnit.test("'resolutions' config is saved during the build for progressively loa
 		assert.ok(/"three": "1.0.0"/.test(source), "it worked");
 	})
 	.then(done, helpers.fail(assert, done));
-
 });
+
+QUnit.test("'map' config is preserved", function(assert){
+	var done = assert.async();
+
+	var loader = helpers.clone()
+		.rootPackage({
+			name: "app",
+			main: "main.js",
+			version: "1.0.0",
+			dependencies: {
+				"dep": "1.0.0"
+			}
+		})
+		.withPackages([{
+			name: "dep",
+			main: "main.js",
+			version: "1.0.0"
+		}])
+		.loader;
+
+	loader.npmContext = {
+		pkgInfo: [
+			{name:"app",main:"main.js",version:"1.0.0", fileUrl: "package.json",
+			steal: {
+				map: {
+					"dep/main": "dep/other"
+				}
+			}}
+		]
+	};
+	loader.npmContext.pkgInfo["app@1.0.0"] = true;
+
+	helpers.init(loader)
+	.then(function(){
+		//return loader.normalize("dep", "app@1.0.0#main");
+	})
+	.then(function(){
+		let pkg = utils.filter(loader.npmContext.pkgInfo, function(pkg){
+			return pkg.name === "app" && pkg.version === "1.0.0";
+		})[0];
+		assert.equal(pkg.steal.map["dep/main"], "dep/other");
+	})
+	.then(done, helpers.fail(assert, done));
+});
+
 
 QUnit.module("Importing npm modules using 'browser' config");
 


### PR DESCRIPTION
When steal-tools runs its build it loads each bundle separately a new
loader like so:

- a
- b
- c

If `b` has some configuration needed for its production bundle and `c`
runs through without that configuration, that configuration will be
omited.

This fixes it so that each time we load a new bundle we use the previous
bundles configuration as a starting point.

Closes #216