### PR TITLE
Only extend plain objects.

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -47,7 +47,7 @@ var utils = {
 			if(deep) {
 				if(utils.isArray(val)) {
 					d[prop] = slice.call(val);
-				} else if(utils.isObject(val)) {
+				} else if(utils.isPlainObject(val)) {
 					d[prop] = utils.extend({}, val, deep, set);
 				} else {
 					d[prop] = s[prop];
@@ -83,6 +83,10 @@ var utils = {
 	},
 	isObject: function(obj){
 		return typeof obj === "object";
+	},
+	isPlainObject: function(obj){
+		// A plain object has a proto that is the Object
+		return utils.isObject(obj) && (!obj || obj.__proto__ === Object.prototype);
 	},
 	isArray: Array.isArray || function(arr){
 		return Object.prototype.toString.call(arr) === "[object Array]";

--- a/test/normalize_test.js
+++ b/test/normalize_test.js
@@ -686,6 +686,9 @@ QUnit.test("Configuration with circular references works", function(assert){
 	var someObject = {};
 	someObject.foo = someObject;
 
+	var Typed = function(){this.isTyped = true};
+	var typeInst = new Typed();
+
 	var loader = helpers.clone()
 		.rootPackage({
 			name: "app",
@@ -698,7 +701,8 @@ QUnit.test("Configuration with circular references works", function(assert){
 	.then(function(){
 		loader.config({
 			instantiated: {
-				something: someObject
+				something: someObject,
+				typeInst: typeInst
 			}
 		});
 		assert.ok(true, "no infinite recursion");


### PR DESCRIPTION
Trying to extend typed objects cause infinite recursion easily when
deeply extending. The fix is to check if the object's __proto__ is
Object.prototype.

Fixes #220