### PR TITLE
Harmonize steal

### DIFF
--- a/npm-utils.js
+++ b/npm-utils.js
@@ -665,6 +665,8 @@ var utils = {
 		 * @returns data
 		 */
 		transform: function(loader, load, data) {
+			// harmonize steal config
+			data.steal = utils.pkg.config(data);
 			var fn = loader.jsonOptions && loader.jsonOptions.transform;
 			if(!fn) return data;
 			return fn.call(loader, load, data);

--- a/npm.js
+++ b/npm.js
@@ -51,13 +51,15 @@ exports.translate = function(load){
 	pkgVersion[pkg.version] = context.versions.__default = pkg;
 
 	// backwards compatible for < npm 3
-	var steal = utils.pkg.config(pkg);
-	if(steal && steal.npmAlgorithm === "nested") {
+	var steal = utils.pkg.config(pkg) || {};
+
+	if(steal.npmAlgorithm === "nested"){
 		context.isFlatFileStructure = false;
-	} else {
-		pkg.steal = steal = steal || {};
+	}else{
 		steal.npmAlgorithm = "flat";
 	}
+
+	pkg.steal = steal;
 
 	return crawl.root(context, pkg, true).then(function(){
 		// clean up packages so everything is unique
@@ -69,7 +71,6 @@ exports.translate = function(load){
 					delete pkg.browser.transform;
 				}
 				pkg = utils.json.transform(loader, load, pkg);
-				var steal = utils.pkg.config(pkg);
 
 				packages.push({
 					name: pkg.name,
@@ -78,7 +79,7 @@ exports.translate = function(load){
 						pkg.fileUrl :
 						utils.relativeURI(context.loader.baseURL, pkg.fileUrl),
 					main: pkg.main,
-					steal: convert.steal(context, pkg, steal, index === 0),
+					steal: convert.steal(context, pkg, pkg.steal, index === 0),
 					globalBrowser: convert.browser(pkg, pkg.globalBrowser),
 					browser: convert.browser(pkg, pkg.browser || pkg.browserify),
 					jspm: convert.jspm(pkg, pkg.jspm),

--- a/test/json-options/dev.html
+++ b/test/json-options/dev.html
@@ -23,7 +23,6 @@
 		},
 		jsonOptions: {
 			transform: function (load, json) {
-				debugger;
 				if (json.name === 'npm-app') {
 					delete json.foo;
 					delete json.steal.someConfig;

--- a/test/json-options/dev.html
+++ b/test/json-options/dev.html
@@ -22,14 +22,16 @@
 			"css": "../../node_modules/steal/ext/css.js"
 		},
 		jsonOptions: {
-			transform: function(load, json) {
-				if(json.fileUrl === "./package.json" && json.name === 'npm-app') {
+			transform: function (load, json) {
+				debugger;
+				if (json.name === 'npm-app') {
 					delete json.foo;
-				}
-				for (var prop in json) {
-					if(prop[0] === '_') {
-						delete json[prop];
-					}
+					delete json.steal.someConfig;
+				} else if (json.name == 'dep1') {
+					delete json._npmVersion;
+					delete json.steal.someConfig;
+				}else if(json.bar){
+                    json.bar = "bar";
 				}
 
 				return json;

--- a/test/json-options/foo.json
+++ b/test/json-options/foo.json
@@ -1,3 +1,4 @@
 {
-  "foo": "bar"
+  "foo": "bar",
+  "bar": "foo"
 }

--- a/test/json-options/main.js
+++ b/test/json-options/main.js
@@ -3,7 +3,6 @@ var dep1 = require('dep1');
 
 if(window.QUnit) {
 	var myJson = require('foo.json');
-	debugger;
 	QUnit.equal(typeof myJson, "object", "foo.json loaded and parsed");
 
 	QUnit.equal(myJson.foo, "bar");

--- a/test/json-options/main.js
+++ b/test/json-options/main.js
@@ -2,15 +2,21 @@ var loader = require('@loader');
 var dep1 = require('dep1');
 
 if(window.QUnit) {
-	var json = require('foo.json');
+	var myJson = require('foo.json');
+	debugger;
+	QUnit.equal(typeof myJson, "object", "foo.json loaded and parsed");
 
-	QUnit.equal(json.foo, "bar", "foo.json foo property not was not deleted");
+	QUnit.equal(myJson.foo, "bar");
+	QUnit.equal(myJson.bar, "bar", "json property was modifed");
 
 	var appPackage = loader.npmContext.pkgInfo[0];
 	QUnit.ok(!appPackage.foo, "foo property was deleted in apps package.json");
+	QUnit.ok(!appPackage.steal.someConfig);
 
 	var dep1Package = loader.npmContext.pkgInfo[1];
 	QUnit.ok(!dep1Package._npmVersion, "_npmVersion property was deleted in dep1s package.json");
+	QUnit.ok(dep1Package.steal.main);
+	QUnit.ok(!dep1Package.steal.someConfig, "system config was rewritten to steal and deleted");
 
 	removeMyself();
 } else {

--- a/test/json-options/node_modules/dep1/package.json
+++ b/test/json-options/node_modules/dep1/package.json
@@ -4,5 +4,9 @@
 	"main": "main",
 	"dependencies": {
 	},
-	"_npmVersion": "3.3.12"
+	"_npmVersion": "3.3.12",
+	"system": {
+		"main": "main",
+		"someConfig": true
+	}
 }

--- a/test/json-options/package.json
+++ b/test/json-options/package.json
@@ -10,7 +10,7 @@
 		"transform": []
 	},
 	"steal": {
-		"ignoreBrowser": true
+		"someConfig": true
 	},
 	"foo": "bar"
 }


### PR DESCRIPTION
this PR harmonize the steal config in `jsonTransform`
if we don't do this, users have to check in `jsonTransform` if `steal` or the old `system` config is used by a dependency.
now you can use `steal` in your `jsonTransform` whatever the config looks like 