### PR TITLE
Only retry when fetch failed because of 404

### DIFF
--- a/npm-extension.js
+++ b/npm-extension.js
@@ -82,7 +82,7 @@ exports.addExtension = function(System){
 				name = name + "index";
 			}
 		}
-		
+
 		// Using the current package, get info about what it is probably asking for
 		var parsedModuleName = utils.moduleName.parseFromPackage(this, refPkg,
 																 name,
@@ -132,7 +132,7 @@ exports.addExtension = function(System){
 					depPkg = utils.pkg.findDepWalking(this, refPkg,
 													  parsedModuleName.packageName);
 				} else {
-					depPkg = utils.pkg.findDep(this, refPkg, 
+					depPkg = utils.pkg.findDep(this, refPkg,
 											   parsedModuleName.packageName);
 				}
 			}
@@ -292,13 +292,17 @@ exports.addExtension = function(System){
 
 		if(utils.moduleName.isNpm(load.name)) {
 			fetchPromise = fetchPromise.then(null, function(err){
+				if(err.statusCode !== 404) {
+					return Promise.reject(err);
+				}
+
 				// Begin attempting retries. `retryTypes` defines different
 				// types of retries to do, currently retrying on the
 				// /index and /package.json conventions.
 				var types = [].slice.call(retryTypes);
 
 				return retryAll(types, err);
-				
+
 				function retryAll(types, err){
 					if(!types.length) {
 						throw err;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash": "~4.17.2",
     "qunit": "~0.9.1",
     "qunitjs": "~1.22.0",
-    "steal": "^1.0.0",
+    "steal": "^1.2.0-pre.2",
     "steal-conditional": "^0.3.0",
     "steal-qunit": "^1.0.0",
     "testee": "^0.3.0"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,6 +6,8 @@ function Runner(System){
 	this.BaseSystem = System;
 	this.deps = [];
 	this.sources = {};
+	this.fetchAllowed = {};
+	this.fetchAll = false;
 }
 
 Runner.prototype.clone = function(){
@@ -63,7 +65,11 @@ Runner.prototype.clone = function(){
 			var source = runner.sources[load.name];
 			return Promise.resolve(source);
 		}
+		if(runner.fetchAll || runner.fetchAllowed[load.name]) {
+			return fetch.apply(this, arguments);
+		}
 		var error = new Error("Unable to find: " + load.name);
+		error.statusCode = 404;
 		return Promise.reject(error);
 	};
 
@@ -151,7 +157,7 @@ Runner.prototype.withConfig = function(cfg){
 
 Runner.prototype.npmVersion = function(version){
 	if(arguments.length === 0) {
-		return this._version; 
+		return this._version;
 	}
 	this._version = version;
 	return this;
@@ -168,6 +174,15 @@ Runner.prototype._addVersion = function(){
 		system.npmAlgorithm = this.algorithm = 'flat';
 		this.npmVersion(3);
 	}
+};
+
+Runner.prototype.allowFetch = function(val){
+	if(val === true) {
+		this.fetchAll = true;
+	} else {
+		this.fetchAllowed[val] = true;
+	}
+	return this;
 };
 
 Runner.prototype.isFlat = function(){


### PR DESCRIPTION
We should only run the retry algorithm if the fetch failed because of a
404. If the fetch failed for another reason (such as a bug in a plugin),
	it should be rejected with that error.

Closes #227