### PR TITLE
Remove live-reload code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 node_js:
-    - 0.12
     - 4
-    - 5.5
+    - 6
+    - node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script: npm test
 sudo: false
 addons:
-  firefox: "50.0"
+  firefox: latest

--- a/npm-crawl.js
+++ b/npm-crawl.js
@@ -10,11 +10,12 @@ var crawl = {
 	/**
 	 * Adds the properties read from a package's source to the `pkg` object.
 	 * @param {Object} context
-	 * @param {NpmPackage} pkg - 
+	 * @param {NpmPackage} pkg -
 	 * @param {String} source
 	 * @return {NpmPackage}
 	 */
 	processPkgSource: function(context, pkg, source) {
+		source = source || "{}";
 		var packageJSON = JSON.parse(source);
 		utils.extend(pkg, packageJSON);
 		context.packages.push(pkg);
@@ -137,7 +138,7 @@ var crawl = {
 			childPkg.origFileUrl = utils.path.depPackage(pkg.fileUrl, childPkg.name);
 		} else {
 			// npm 2
-			childPkg.origFileUrl = childPkg.nestedFileUrl = 
+			childPkg.origFileUrl = childPkg.nestedFileUrl =
 				utils.path.depPackage(pkg.fileUrl, childPkg.name);
 
 			if(isFlat) {
@@ -147,12 +148,12 @@ var crawl = {
 			}
 		}
 
-		// check if childPkg matches a parent's version ... if it 
+		// check if childPkg matches a parent's version ... if it
 		// does ... do nothing
 		if(crawl.hasParentPackageThatMatches(context, childPkg)) {
 			return;
 		}
-		
+
 		if(crawl.isSameRequestedVersionFound(context, childPkg)) {
 			return;
 		}
@@ -204,12 +205,12 @@ var crawl = {
 	 */
 	getDependencies: function(loader, packageJSON, isRoot){
 		var deps = crawl.getDependencyMap(loader, packageJSON, isRoot);
-		
+
 		var dependencies = [];
 		for(var name in deps) {
 			dependencies.push(deps[name]);
 		}
-		
+
 		return dependencies;
 	},
 	/**
@@ -241,7 +242,7 @@ var crawl = {
 			config.npmDependencies = convertToMap(npmDependencies);
 		}
 		npmIgnore = npmIgnore || {};
-		
+
 		var deps = {};
 
 		addDeps(packageJSON, packageJSON.peerDependencies || {}, deps,
@@ -268,13 +269,13 @@ var crawl = {
 			context.versions[childPkg.name] = {};
 		}
 		var versions = context.versions[childPkg.name];
-		
+
 		var requestedRange = childPkg.version;
-		
+
 		if( !SemVer.validRange(childPkg.version) ) {
-			
+
 			if(/^[\w_\-]+\/[\w_\-]+(#[\w_\-]+)?$/.test(requestedRange)  ) {
-							
+
 				requestedRange = "git+https://github.com/"+requestedRange;
 				if(!/(#[\w_\-]+)?$/.test(requestedRange)) {
 					requestedRange += "#master";
@@ -282,7 +283,7 @@ var crawl = {
 			}
 		}
 		var version = versions[requestedRange];
-		
+
 		if(!version) {
 			versions[requestedRange] = childPkg;
 		} else {
@@ -293,14 +294,14 @@ var crawl = {
 	},
 	hasParentPackageThatMatches: function(context, childPkg){
 		// check paths
-		var parentAddress = childPkg._isPeerDependency ? 
+		var parentAddress = childPkg._isPeerDependency ?
 			utils.path.peerNodeModuleAddress(childPkg.origFileUrl) :
 			utils.path.parentNodeModuleAddress(childPkg.origFileUrl);
 		while( parentAddress ) {
 			var packageAddress = parentAddress+"/"+childPkg.name+"/package.json";
 			var parentPkg = context.paths[packageAddress];
 			if(parentPkg) {
-				if(SemVer.valid(parentPkg.version) && 
+				if(SemVer.valid(parentPkg.version) &&
 				   SemVer.satisfies(parentPkg.version, childPkg.version)) {
 					return parentPkg;
 				}
@@ -438,7 +439,7 @@ function addDeps(packageJSON, dependencies, deps, type, defaultProps){
 
 		return !!(!npmIgnore || !npmIgnore[name]);
 	}
-	
+
 	defaultProps = defaultProps || {};
 	var val;
 	for(var name in dependencies) {
@@ -519,7 +520,7 @@ utils.extend(FetchTask.prototype, {
 		var pkg = pkg || this.getPackage();
 		var requestedVersion = this.requestedVersion;
 
-		return SemVer.validRange(requestedVersion) && 
+		return SemVer.validRange(requestedVersion) &&
 			SemVer.valid(pkg.version) ?
 			SemVer.satisfies(pkg.version, requestedVersion) : true;
 	},

--- a/npm-load.js
+++ b/npm-load.js
@@ -50,7 +50,7 @@ exports.makeSource = function(context, pkg){
 		(pkgMain ? "if(!loader.main){ loader.main = " +
 		 JSON.stringify(pkgMain) + "; }\n" : "") +
 		"loader._npmExtensions = [].slice.call(arguments, 2);\n" +
-		"("+ translateConfig.toString() + ")(loader, " + 
+		"("+ translateConfig.toString() + ")(loader, " +
 		JSON.stringify(context.pkgInfo, null, " ") + ", " +
 		JSON.stringify(options, null, " ") + ");\n" +
 	"});";
@@ -153,20 +153,6 @@ var translateConfig = function(loader, packages, options){
 			fn.call(arr, arr[i]);
 		}
 	};
-	var setupLiveReload = function(){
-		var hasLiveReload = !!(loader.liveReloadInstalled || loader._liveMap);
-		if(hasLiveReload) {
-			loader["import"]("live-reload", { name: module.id }).then(function(reload){
-				reload.dispose(function(){
-					// Remove state created by the config.
-					delete loader.npm;
-					delete loader.npmPaths;
-					delete loader.npmParentMap;
-					delete loader.npmContext;
-				});
-			});
-		}
-	};
 
 	var ignoredConfig = ["bundle", "configDependencies", "transpiler"];
 	packages.reverse();
@@ -215,7 +201,6 @@ var translateConfig = function(loader, packages, options){
 			loader.config(ext.systemConfig);
 		}
 	});
-	setupLiveReload();
 };
 
 /**


### PR DESCRIPTION
In Steal 0.16 we needed special live-reload behavior because when
steal-npm was imported it would fetch all of the package.jsons. Now that
we only fetch package.jsons as they are needed there isn't the need to
flush out the old state, as the state remains valid.

This is the cause of https://github.com/donejs/donejs/issues/790