### PR TITLE
Remove the root package on a live-reload

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -16,7 +16,7 @@ var isNode = typeof process === "object" &&
  */
 exports.translate = function(load){
 	var loader = this;
-	
+
 	// This could be an empty string if the fetch failed.
 	if(load.source == "") {
 		return "define([]);";

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -18,6 +18,12 @@ Runner.prototype.clone = function(){
 		__useDefault: true,
 		"default": loader
 	}));
+	loader.set("@steal", loader.newModule({
+		__useDefault: true,
+		"default": steal
+	}));
+
+	loader.paths["live-reload"] = "node_modules/steal/ext/live-reload.js";
 
 	var allow = {};
 	utils.forEach([
@@ -30,7 +36,8 @@ Runner.prototype.clone = function(){
 		"npm-extension",
 		"npm-utils",
 		"semver",
-		"@loader"
+		"@loader",
+		"@steal"
 	], function(name){
 		allow[name] = true;
 	});
@@ -76,6 +83,12 @@ Runner.prototype.clone = function(){
 	var normalize = loader.normalize;
 	loader.normalize = function(name){
 		if(this._helperInited) {
+			return normalize.apply(this, arguments);
+		}
+
+		var steal = runner.root.steal || {};
+		var configDeps = steal.configDependencies || [];
+		if(configDeps.indexOf(name) !== -1) {
 			return normalize.apply(this, arguments);
 		}
 

--- a/test/load_test.js
+++ b/test/load_test.js
@@ -43,3 +43,35 @@ QUnit.test("System.main contains the package name with directories.lib",
 	})
 	.then(done, helpers.fail(assert, done));
 });
+
+QUnit.test("Configuration is reapplied after a live-reload", function(assert){
+	var done = assert.async();
+
+	var root = {
+		name: "app",
+		version: "1.0.0",
+		main: "main.js",
+		steal: {
+			configDependencies: ["live-reload"],
+			foo: "baz"
+		}
+	};
+
+	var runner = helpers.clone()
+		.rootPackage(root)
+		.allowFetch("live-reload");
+
+	var loader = runner.loader;
+
+	helpers.init(loader)
+	.then(function(){
+		root.steal.foo = "bar";
+
+		var liveReload = loader.get("live-reload").default;
+		return liveReload("package.json!npm");
+	})
+	.then(function(){
+		assert.equal(loader.foo, "bar", "config applied after a live-reload");
+	})
+	.then(done, helpers.fail(assert, done));
+});


### PR DESCRIPTION
When the package.json!npm module is disposed during a live-reload,
	 remove the root package from the npmContext so that it is reloaded
	 and any configuration that has been added is applied to the global
	 `steal.loader`.

Fixes #232